### PR TITLE
Bug fix and feature addition

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,36 +31,44 @@ else
     fi
 fi
 
-# Determine computing environment
 
-echo "Are you on an Livermore Computing system ? (y/n)"
-read IS_LC
+# Determine computing environment and attempt to load module files automatically
+
+lochost=`hostname`
+hosttype=""
+
+if [[ $string == *"arc-ts.umich.edu"* ]]; then
+    hosttype=UM-ARC
+elif [[ $string == *"arc-ts.umich.edu"* ]]; then
+    hosttype=LLNL-LC
+fi
 
 
-# Setup compilers
+
+# Load module files and configure compilers
 
 ICC=`which g++`
 
-if [[ "$IS_LC" == "y" ]] ; then
-    module load cmake/3.21.1
-    module load intel/18.0.1
-    module load impi/2018.0
-    
+if [[ "$hosttype" == "LLNL-LC" ]] ; then
+    ./modfiles/LLNL-LC.mod
+    ICC=`which icc`
+elif [[ "$hosttype" == "UM-ARC" ]] ; then
+    ./modfiles/UM-ARC.mod
     ICC=`which icc`
 fi
 
-MPI=`which mpicxx` # /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.1/bin/mpicxx
+MPI=`which mpicxx`
 
 
 # Grab and install dependencies
 
 if [[ ! -d imports ]] ; then
-    ./clone-all.sh 1 $IS_LC
+    ./clone-all.sh
 fi
 
-# Compile dlars
+# Compile dlars if mpi compilers are available on a HPC platform
 
-if [[ "$IS_LC" == "y" ]] ; then
+if [[ ! -z $hosttype ]] ; then
     cd contrib/dlars/src
     make
     cd - 1&>/dev/null
@@ -68,18 +76,22 @@ fi
 
 # Compile molanal
 
+
 cd contrib/molanal/src
 make molanal.new
-cd - 1&>/dev/null
+cd ../../..
+
 
 # Clean up previous installation,
 
 ./uninstall.sh $PREFX
 
+
 # Move into build directory
 
 mkdir build
 cd build
+
 
 # Generate cmake flags
 

--- a/modfiles/LLNL-LC.mod
+++ b/modfiles/LLNL-LC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.21.1
+module load intel/18.0.1
+module load impi/2018.0

--- a/modfiles/UM-ARC.mod
+++ b/modfiles/UM-ARC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.22.2  
+module load intel/18.0.5
+module load impi/2018.4.274


### PR DESCRIPTION
1. Fix compilation bug at molanal in install.sh
2. Introduce modfiles folder*

*Allows .modfiles to be added for different HPC. Currently, files have been added for LLNL's LC and UM's ARC. Install.sh automatically determines which of the modfiles/*.mod to execute based on hostname. Easily extensible to other HPC platforms.