### PR TITLE
Hotfix: Add missing LLNL-LC.mod MKL line for DLARS compilation

### DIFF
--- a/modfiles/LLNL-LC.mod
+++ b/modfiles/LLNL-LC.mod
@@ -1,3 +1,4 @@
 module load cmake/3.21.1
 module load intel/18.0.1
 module load impi/2018.0
+module load mkl


### PR DESCRIPTION
This fix is required for automated DLARS compilation via export hosttype=LLNL-LC; ./install.sh, if the user doesn't manually pre-load modules.