### PR TITLE
Python on GreatLakes

### DIFF
--- a/modfiles/UM-ARC.mod
+++ b/modfiles/UM-ARC.mod
@@ -2,4 +2,4 @@ module load cmake/3.22.2
 module load intel/2022.1.2
 module load impi/2021.5.1
 module load mkl/2022.0.2 
-
+module load python3.9-anaconda/2021.11


### PR DESCRIPTION
The default python on the great lakes cluster does not have some of the python libraries that we regularly use so we should load anaconda's module of python which has the libraries that we will need. Regularly before a commit all of the tests should be run but since this is not a production change the tests were not done.