### PR TITLE
resolve lasso norm deprecation problem in newer sklearn versions

### DIFF
--- a/src/chimes_lsq.py
+++ b/src/chimes_lsq.py
@@ -68,6 +68,7 @@ def main():
     if args.algorithm in sk_algos:
         from sklearn import linear_model
         from sklearn import preprocessing
+        from sklearn.pipeline import make_pipeline
         
     #############################################
     # Read weights, if used
@@ -290,12 +291,27 @@ def main():
         print ('! LASSO alpha = %11.4e' % args.alpha)
 
         if DO_WEIGHTING:
-            reg = linear_model.LassoLars(alpha=args.alpha,fit_intercept=False,fit_path=False,verbose=True,max_iter=100000, copy_X=False)
+            reg = make_pipeline(preprocessing.StandardScaler(with_mean=False, with_std=False), 
+                              linear_model.LassoLars(
+                                  alpha=args.alpha,
+                                  fit_intercept=False,
+                                  fit_path=False,
+                                  verbose=True,
+                                  max_iter=100000,
+                                  copy_X=False)
+                              )
             reg.fit(weightedA,weightedb)
         else:
-            reg = linear_model.LassoLars(alpha=args.alpha,fit_intercept=False,fit_path=False,verbose=True,max_iter=100000)
+            reg = make_pipeline(preprocessing.StandardScaler(with_mean=False, with_std=False), 
+                                linear_model.LassoLars(
+                                    alpha=args.alpha,
+                                    fit_intercept=False,
+                                    fit_path=False,
+                                    verbose=True,
+                                    max_iter=100000)
+                                )
             reg.fit(A,b)
-        x       = reg.coef_[0]
+        x       = reg.steps[1][1].coef_[0] # 1st [1] refers to chain index, 2nd [1] parse out second element in tuple, i.e., linear_model.LassoLars()
         np      = count_nonzero_vars(x)
         nvars   = np
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->

## Description
Scikit-learn Lasso function deprecates the `normalize` command in version 1.4. Therefore, we need to change our CHIMES_LSQ implementation accordingly. 
In the original implementation, sklearn sets default `normalize=True`; however, the `normalize` kwarg is ignored when the `fit_intercept=False`, which is what ChIMES_LSQ implemented. Therefore, ChIMES_LSQ does not normalize data. 
To accomondate the deprecation, I used the `make_pipeline` and `StandardScalar` functions in scikit-learn, with `with_mean=False, with_std=False` to achieve an equivalent purpose. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #28 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

Use the `lsq2` test case folder in `test_suite-lsq`. I first ran `make generate` using the **pre-modified** `chimes_lsq.py` to generate the `correct_output` folder for the Stampede3 HPC. Then I copied over the folder and ran the `make all` command using the **modified** `chimes_lsq.py` to compare the param files generated using different solving algorithms. 

## Change log

<!-- Propose a change log entry. -->
```
reg = make_pipeline(preprocessing.StandardScaler(with_mean=False, with_std=False), 
                  linear_model.LassoLars(
                      alpha=args.alpha,
                      fit_intercept=False,
                      fit_path=False,
                      verbose=True,
                      max_iter=100000,
                      copy_X=False)
                  )
```

## Checklist:

- [x] I have ran the chimes-md and chimes-lsq test suites and attached the log files in this PR.   
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/LindseyLab-umich/chimes_lsq-LLfork/blob/main/doc/source/contributing.rst).
- [x] I agree with the terms of the [**ChIMES Contributor Agreement**](link).
- [x] My name is on the list of contributors (`path/to/file`) in the pull request source branch.
