### PR TITLE
added fast ridge algorithm for time and memory efficiency

### DIFF
--- a/src/chimes_lsq.py
+++ b/src/chimes_lsq.py
@@ -297,7 +297,6 @@ def main():
 
         x = numpy.linalg.solve(ATA_reg, ATb)
         
-        np    = count_nonzero_vars(x)
         nvars = np
         print ("! Ridge alpha = %11.4e" % args.alpha)
 

--- a/src/chimes_lsq.py
+++ b/src/chimes_lsq.py
@@ -285,6 +285,21 @@ def main():
         x = reg.coef_
         nvars = np
         print ("! Ridge alpha = %11.4e" % args.alpha)
+        
+    elif args.algorithm == 'fast_ridge':
+        print ('! fast ridge regression used')
+
+        ATA = A.T @ A
+        ATb = A.T @ b
+
+        ATA_reg = ATA.copy()
+        numpy.fill_diagonal(ATA_reg, ATA_reg.diagonal() + args.alpha)
+
+        x = numpy.linalg.solve(ATA_reg, ATb)
+        
+        np    = count_nonzero_vars(x)
+        nvars = np
+        print ("! Ridge alpha = %11.4e" % args.alpha)
 
     elif args.algorithm == 'ridgecv':
         alpha_ar = [1.0e-06, 3.2e-06, 1.0e-05, 3.2e-05, 1.0e-04, 3.2e-04, 1.0e-03, 3.2e-03]


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->

## Description

Added `fast_ridge` as an algorithm for solving an A matrix. This approach uses the normal equation `A.T@A x = A.T @ b`  in the `fast_svd` algorithm. This approach can speed up solving and improve memory efficiency. 

## Motivation and context

Resolve the memory issue using ridge regression. 

## How has this been tested?
tested on `lsq2` in `test_suite-lsq`. See the zip file. Used `vimdiff` to compare `params.txt` with the one in the `correct_output` folder, solved using ridge with `alpha=1.0e-3`. All the summary variables, including RMS force error and max abs variable matches exactly. The deviation in individual coefficients generally starts in the 4th decimal point and onwards, which is observed in regular `ridge` fitting as well and is attributed to machine precision between different machines. 

[lsq2_test_fast_ridge_v2.zip](https://github.com/user-attachments/files/25845553/lsq2_test_fast_ridge_v2.zip)
(updated)

## Change log
```
python3 /path/to/chimes_lsq-myfork/build/chimes_lsq.py --algorithm=fast_ridge > params.txt
```

## Checklist:

- [x] I have ran the chimes-md and chimes-lsq test suites and attached the log files in this PR.   
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/LindseyLab-umich/chimes_lsq-LLfork/blob/main/doc/source/contributing.rst).
- [x] I agree with the terms of the [**ChIMES Contributor Agreement**](link).
- [x] My name is on the list of contributors (`path/to/file`) in the pull request source branch.
